### PR TITLE
ST-6372-FIX_Xero-Kept-Disconnecting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "php": ">=7.4",
     "guzzlehttp/guzzle": "^7.0.1",
     "ext-json": "*",
-    "spatie/data-transfer-object": "^2.5"
+    "spatie/data-transfer-object": "2.8.1"
   },
   "require-dev": {
     "orchestra/testbench": "^5.0"

--- a/src/Actions/RefreshAccessTokens.php
+++ b/src/Actions/RefreshAccessTokens.php
@@ -28,13 +28,16 @@ class RefreshAccessTokens extends Action
 
             $xero->setAccessToken(data_get($data, 'access_token'));
             $xero->setRefreshToken(data_get($data, 'refresh_token'));
+            $xero->setExpiredAt(now()->addSeconds(data_get($data, 'expires_in')));
             $xero->persist();
         } catch (ClientException $e) {
-            $xero->setAccessToken(null);
-            $xero->setRefreshToken(null);
-            $xero->persist();
+            if($xero->getExpiredAt()->diffInDays(now()) >= 60) {
+                $xero->setAccessToken(null);
+                $xero->setRefreshToken(null);
+                $xero->persist();
 
-            $this->log('XERO disconnected!');
+                $this->log('XERO disconnected!');
+            }
 
             return false;
         }

--- a/src/Actions/RefreshAccessTokensInternal.php
+++ b/src/Actions/RefreshAccessTokensInternal.php
@@ -28,14 +28,17 @@ class RefreshAccessTokensInternal extends Action
 
             $xero->setAccessToken(data_get($data, 'access_token'));
             $xero->setRefreshToken(data_get($data, 'refresh_token'));
+            $xero->setExpiredAt(now()->addSeconds(data_get($data, 'expires_in')));
             $xero->persist();
         } catch (ClientException $e) {
-            $xero->setAccessToken(null);
-            $xero->setRefreshToken(null);
-            $xero->persist();
+            if($xero->getExpiredAt()->diffInDays(now()) >= 60) {
+                $xero->setAccessToken(null);
+                $xero->setRefreshToken(null);
+                $xero->persist();
 
-            $this->log('XERO disconnected!');
-
+                $this->log('XERO disconnected!');
+            }
+            
             return false;
         }
 


### PR DESCRIPTION
Fix issues where xero kept disconnecting due to api limit and wrong handling for refreshing token
There is breaking changes in [spatie/data-transfer-object version 2.8.2](https://github.com/spatie/data-transfer-object/releases/tag/2.8.2) onwards hence will specify in composer.json to use v2.8.1 for now and rectify this on seperate ticket in the future.